### PR TITLE
Adds a flag to check whether the app is running on a Device or Simulator/Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ public enum Idiom
 }
 ```
 
+**IsDevice**
+```csharp
+/// <summary>
+/// Checks whether this is a real device or an emulator/simulator
+/// </summary>
+bool IsDevice { get; }
+```
+
+Returns `true`, if the app is running on a real physical device. `false` is returned if the app is running on an emulator or simulator (whatever applies for the platform).
+
 
 #### Contributions
 Contributions are welcome! If you find a bug please report it and if you want a feature please report it.

--- a/src/DeviceInfo.Plugin.Abstractions/IDeviceInfo.cs
+++ b/src/DeviceInfo.Plugin.Abstractions/IDeviceInfo.cs
@@ -68,5 +68,10 @@ namespace Plugin.DeviceInfo.Abstractions
         /// Get the idom of the device
         /// </summary>
         Idiom Idiom { get; }
+
+        /// <summary>
+        /// Checks whether this is a real device or an emulator/simulator
+        /// </summary>
+        bool IsDevice { get; }
     }
 }

--- a/src/DeviceInfo.Plugin.Android/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.Android/DeviceInfoImplementation.cs
@@ -135,5 +135,21 @@ namespace Plugin.DeviceInfo
                 return  minWidthDp >= TabletCrossover ? Idiom.Tablet : Idiom.Phone;
             }
         }
+
+        /// <summary>
+        /// Checks whether this is a real device or an emulator/simulator
+        /// 
+        /// Shamelessly taken from https://stackoverflow.com/a/13635166
+        /// </summary>
+        public bool IsDevice => !(
+            Build.Fingerprint.StartsWith("generic", StringComparison.InvariantCulture)
+            || Build.Fingerprint.StartsWith("unknown", StringComparison.InvariantCulture)
+            || Build.Model.Contains("google_sdk")
+            || Build.Model.Contains("Emulator")
+            || Build.Model.Contains("Android SDK built for x86")
+            || Build.Manufacturer.Contains("Genymotion")
+            || (Build.Brand.StartsWith("generic", StringComparison.InvariantCulture) && Build.Device.StartsWith("generic", StringComparison.InvariantCulture))
+            || Build.Product.Equals("google_sdk", StringComparison.InvariantCulture)
+        );
     }
 }

--- a/src/DeviceInfo.Plugin.UWP/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.UWP/DeviceInfoImplementation.cs
@@ -177,5 +177,12 @@ namespace Plugin.DeviceInfo
                 }
             }
         }
+
+        /// <summary>
+        /// Checks whether this is a real device or an emulator/simulator
+		/// 
+		/// Source: http://igrali.com/2014/07/17/get-device-information-windows-phone-8-1-winrt/
+        /// </summary>
+		public bool IsDevice => deviceInfo.SystemProductName == "Virtual";
     }
 }

--- a/src/DeviceInfo.Plugin.iOS/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.iOS/DeviceInfoImplementation.cs
@@ -29,8 +29,12 @@ using ObjCRuntime;
 using System.Diagnostics;
 #elif __WATCHOS__
 using WatchKit;
+using ObjCRuntime;
+using Platform = Plugin.DeviceInfo.Abstractions.Platform;
 #else
 using UIKit;
+using ObjCRuntime;
+using Platform = Plugin.DeviceInfo.Abstractions.Platform;
 #endif
 using System;
 
@@ -237,5 +241,14 @@ namespace Plugin.DeviceInfo
             }
 
         }
+
+        /// <summary>
+        /// Checks whether this is a real device or an emulator/simulator
+        /// </summary>
+#if __MACOS__
+        public bool IsDevice => true; // There is no simulator for mac OS
+#else
+        public bool IsDevice => Runtime.Arch == Arch.DEVICE;
+#endif
     }
 }


### PR DESCRIPTION
The UWP integration is not build because I have no windows device at hand!

Fixes #26 

Changes Proposed in this pull request:
- Adds a `IsDevice` flag to `IDeviceInfo` and all implementations