### PR TITLE
Addition of device language, Tizen implementation missing

### DIFF
--- a/src/DeviceInfo.Plugin.Abstractions/IDeviceInfo.cs
+++ b/src/DeviceInfo.Plugin.Abstractions/IDeviceInfo.cs
@@ -95,5 +95,10 @@ namespace Plugin.DeviceInfo.Abstractions
         /// Checks whether this is a real device or an emulator/simulator
         /// </summary>
         bool IsDevice { get; }
+
+        /// <summary>
+        /// Returns the current device language, as a two character string, e.g. "en", "fr", "nl"...
+        /// </summary>
+        string Language { get; }
     }
 }

--- a/src/DeviceInfo.Plugin.Android/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.Android/DeviceInfoImplementation.cs
@@ -252,5 +252,8 @@ namespace Plugin.DeviceInfo
             || (Build.Brand.StartsWith("generic", StringComparison.InvariantCulture) && Build.Device.StartsWith("generic", StringComparison.InvariantCulture))
             || Build.Product.Equals("google_sdk", StringComparison.InvariantCulture)
         );
+
+        /// <inheritdoc/>
+        public string Language => Application.Context.Resources.Configuration.Locale.Language;
 	}
 }

--- a/src/DeviceInfo.Plugin.Tizen/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.Tizen/DeviceInfoImplementation.cs
@@ -180,5 +180,8 @@ namespace Plugin.DeviceInfo
 					return false;
 			}
 		}
+
+		/// <inheritdoc/>
+		public string Language => string.Empty;
 	}
 }

--- a/src/DeviceInfo.Plugin.UWP/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.UWP/DeviceInfoImplementation.cs
@@ -1,5 +1,6 @@
 using Plugin.DeviceInfo.Abstractions;
 using System;
+using System.Globalization;
 using Windows.System.Profile;
 using Windows.Security.ExchangeActiveSyncProvisioning;
 using Windows.Foundation.Metadata;
@@ -213,5 +214,8 @@ namespace Plugin.DeviceInfo
 		/// Source: http://igrali.com/2014/07/17/get-device-information-windows-phone-8-1-winrt/
         /// </summary>
 		public bool IsDevice => deviceInfo.SystemProductName == "Virtual";
+
+        /// <inheritdoc/>
+        public string Language => CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
     }
 }

--- a/src/DeviceInfo.Plugin.iOS/DeviceInfoImplementation.cs
+++ b/src/DeviceInfo.Plugin.iOS/DeviceInfoImplementation.cs
@@ -295,5 +295,8 @@ namespace Plugin.DeviceInfo
 #else
         public bool IsDevice => Runtime.Arch == Arch.DEVICE;
 #endif
+
+        /// <inheritdoc/>
+        public string Language => NSLocale.PreferredLanguages[0].Substring(0, 2);
 	}
 }


### PR DESCRIPTION
This PR adds a Language property to retrieve the 2-letter language name of the device. Useful for e.g. multi-language applications defaulting to the device language.

